### PR TITLE
Use Timestamp in weather JSON if available.

### DIFF
--- a/weather/server.js
+++ b/weather/server.js
@@ -22,7 +22,8 @@ app.use(express.static('public'));
 app.use(bodyParser.json());
 
 function saveData(type, req, res) {
-    redisClient.zadd(type, Date.now(), JSON.stringify(req.body), function(err, reply) {
+    var timestamp = 'Timestamp' in req.body ? parseInt(req.body.Timestamp) : Date.now();
+    redisClient.zadd(type, timestamp, JSON.stringify(req.body), function(err, reply) {
         if (err) {
             logger.error(err);
             res.status(500).send(err);


### PR DESCRIPTION
If JSON data received by the weather API endpoint contains a Timestamp key, it will be used as the key in Redis instead of Date.now(). Didn't have a chance to test this much yet, so approach with caution.